### PR TITLE
add linebreak in make run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,5 @@ conda-lock:
 PY_SCRIPT = "test/py_test.py"
 run: 
 	@echo "Running python script $(PY_SCRIPT) in runtime instance of $(IMG_NAME)"
-	docker run $(IMG_NAME) python $(PY_SCRIPT)
+	docker run $(IMG_NAME)
+	python $(PY_SCRIPT)


### PR DESCRIPTION
Add a line break in make run to fix directory not found error on Windows OS